### PR TITLE
DIT-783 | acquia_perz Drupal 10 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "acquia/http-hmac-php": ">=3.4",
         "ext-json": "*",
         "php": ">=7.1",
-        "psr/log": "~1.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "psr/log": "~1.0 || ^3.0",
+        "guzzlehttp/guzzle": "~6.0 || ^7.0"
     },
     "require-dev": {
         "drupal/coder": "^8.3",

--- a/src/PerzApiPhpClient.php
+++ b/src/PerzApiPhpClient.php
@@ -53,7 +53,7 @@ class PerzApiPhpClient extends Client {
     }
 
     // Setting up the User Header string.
-    $user_agent_string = self::LIBRARYNAME . '/' . self::VERSION . ' ' . default_user_agent();
+    $user_agent_string = self::LIBRARYNAME . '/' . self::API_VERSION . ' ' . default_user_agent();
     if (isset($config['client-user-agent'])) {
       $user_agent_string = $config['client-user-agent'] . ' ' . $user_agent_string;
     }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Making compatible with drupal 10 and php 8 [DIT-783](https://backlog.acquia.com/browse/DIT-783)
acquia_perz Drupal 10 Compatibility

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
update dependency version of psr/log and guzzle
